### PR TITLE
Improve title cleaning

### DIFF
--- a/goose/extractors/title.py
+++ b/goose/extractors/title.py
@@ -79,7 +79,7 @@ class TitleExtractor(BaseExtractor):
                 largest_text_length = current_len
                 title = current
 
-        return title
+        return title.strip().rstrip()
 
     def get_title(self):
         """\

--- a/goose/extractors/title.py
+++ b/goose/extractors/title.py
@@ -64,6 +64,21 @@ class TitleExtractor(BaseExtractor):
         # rebuild the title
         title = u" ".join(title_words).strip()
 
+        # Check if clean was bad, then apply old clean method
+        title_pieces = tuple()
+        for splitter in TITLE_SPLITTERS:
+            if splitter in title:
+                title_pieces = title.split(splitter)
+                break
+
+        largest_text_length = 0
+        # find the largest title piece
+        for current in title_pieces:
+            current_len = len(current)
+            if current_len > largest_text_length:
+                largest_text_length = current_len
+                title = current
+
         return title
 
     def get_title(self):

--- a/tests/data/extractors/content/test_allnewlyrics1.json
+++ b/tests/data/extractors/content/test_allnewlyrics1.json
@@ -10,7 +10,7 @@
             "PJ Morton", 
             "Stevie Wonder"
         ], 
-        "title": "\u201cOnly One\u201d Lyrics : PJ Morton (Ft. Stevie Wonder)", 
+        "title": "PJ Morton (Ft. Stevie Wonder)",
         "meta_favicon": "", 
         "meta_lang": "en"
     }

--- a/tests/data/extractors/content/test_businessWeek1.json
+++ b/tests/data/extractors/content/test_businessWeek1.json
@@ -6,7 +6,7 @@
         "final_url": "http://www.businessweek.com/magazine/content/10_34/b4192066630779.htm", 
         "meta_keywords": "Olivia Munn, Attack of the Show, Jon Stewart, Daily Show, G4", 
         "cleaned_text": "Six years ago, Olivia Munn arrived in Hollywood with fading ambitions of making it as a sports reporter and set about deploying", 
-        "title": "Olivia Munn: Queen of the Uncool", 
+        "title": "Queen of the Uncool",
         "meta_favicon": "", 
         "meta_lang": "en"
     }

--- a/tests/data/extractors/content/test_cnn1.json
+++ b/tests/data/extractors/content/test_cnn1.json
@@ -6,7 +6,7 @@
         "final_url": "http://www.cnn.com/2010/POLITICS/08/13/democrats.social.security/index.html", 
         "meta_keywords": "", 
         "cleaned_text": "Washington (CNN) -- Democrats pledged ", 
-        "title": "Democrats to use Social Security against GOP this fall - CNN.com", 
+        "title": "Democrats to use Social Security against GOP this fall",
         "meta_favicon": "http://i.cdn.turner.com/cnn/.element/img/3.0/global/misc/apple-touch-icon.png", 
         "meta_lang": "en"
     }


### PR DESCRIPTION
Додав перевірку, якщо після очистки в title залишаються символи з TITLE_SPLITTERS - застосовуємо старий алгоритм - розбиваємо по цьому роздільнику і шукаємо найдовший рядок, який і приймаємо за title.
